### PR TITLE
Create setup.py needed for lint workflow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+"""Create instructions to build the move package."""
+
+import setuptools
+
+requirements = []
+
+setuptools.setup(
+    name="move",
+    maintainer="Mathilde Papillon",
+    version="0.0.1",
+    maintainer_email="papillon@ucsb.edu",
+    description="Dancing Geometries",
+    long_description=open("README.md", encoding="utf8").read(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/bioshape-lab/move.git",
+    packages=setuptools.find_packages(),
+    install_requires=requirements,
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+    ],
+    zip_safe=False,
+)


### PR DESCRIPTION
This PR creates a setup.py that sets up the github repository as a package that can be installed locally with pip -e.

This is needed to run the lint workflow that otherwise throws an error.

This PR adds Mathilde as the maintainer of the package.